### PR TITLE
✨ 提供“上一题”和“下一题”按钮

### DIFF
--- a/lib/components/indicator.dart
+++ b/lib/components/indicator.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+
+class IndicatorWidget extends StatelessWidget {
+  final int itemCount;
+  final int current;
+
+  final void Function(int index) onTap;
+  final void Function() onTapThumbnail;
+  final void Function() onTapSubmit;
+
+  const IndicatorWidget({
+    super.key,
+    required this.itemCount,
+    required this.onTap,
+    required this.current,
+    required this.onTapThumbnail,
+    required this.onTapSubmit,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          _buildPrevious(),
+          const Spacer(),
+          _buildTextButton(context),
+          const Spacer(),
+          _buildNext(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTextButton(BuildContext context) {
+    return TextButton(
+      onPressed: () {
+        onTapThumbnail();
+      },
+      child: Text(
+        '${current + 1}/ $itemCount',
+        style: TextStyle(color: Theme.of(context).primaryColor),
+      ),
+    );
+  }
+
+  Widget _buildNext() {
+    if (current == itemCount - 1) {
+      return TextButton(
+        onPressed: onTapSubmit,
+        child: Row(
+          children: [
+            Text('submit'),
+            const Icon(Icons.done),
+          ],
+        ),
+      );
+    }
+    return TextButton(
+      onPressed: () => onTap(current + 1),
+      child: Row(
+        children: [
+          Text('Next'),
+          Icon(Icons.arrow_forward),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPrevious() {
+    return Opacity(
+      opacity: current == 0 ? 0 : 1,
+      child: TextButton(
+        onPressed: () => onTap(current - 1),
+        child: Row(
+          children: [
+            Icon(Icons.arrow_back),
+            Text('Previous'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/model/quiz_model.dart
+++ b/lib/model/quiz_model.dart
@@ -18,6 +18,8 @@ class QuizModel extends ChangeNotifier {
 
   bool isLoading = false;
 
+  bool get completed => quizItems.every((item) => item.answered);
+
   QuizModel() {
     fetchAllQuestions();
   }

--- a/lib/pages/quiz/quiz_page.dart
+++ b/lib/pages/quiz/quiz_page.dart
@@ -1,6 +1,6 @@
-import 'dart:math';
-
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_interview_questions/components/indicator.dart';
 import 'package:flutter_interview_questions/model/quiz_model.dart';
 
 import '../result/result_page.dart';
@@ -32,14 +32,34 @@ class _QuizPageState extends State<QuizPage> {
         children: [
           ValueListenableBuilder(
             valueListenable: _currentPage,
-            builder: (context, value, child) => _Overview(
-              currentIndex: value,
-              itemOnTap: (index) => _pageController.animateToPage(
-                index,
-                duration: _kAnimationDuration,
-                curve: _kAnimationCurve,
-              ),
-            ),
+            builder: (BuildContext context1, int value, Widget? child) {
+              return IndicatorWidget(
+                  itemCount: quizItems.length,
+                  current: value,
+                  onTap: (index) {
+                    _pageController.animateToPage(
+                      index,
+                      duration: _kAnimationDuration,
+                      curve: _kAnimationCurve,
+                    );
+                  },
+                  onTapThumbnail: () {
+                    showDialog<String>(
+                      context: context1,
+                      builder: (BuildContext context) =>
+                          _showOverviewDialog(value, context),
+                    );
+                  },
+                  onTapSubmit: () async {
+                    final navigator = Navigator.of(context);
+                    var isGoToResultPage = await _showSubmitDialog(context);
+                    if (isGoToResultPage == true) {
+                      navigator.push<void>(
+                        MaterialPageRoute(builder: (_) => const ResultPage()),
+                      );
+                    }
+                  });
+            },
           ),
           const Divider(),
           Expanded(
@@ -92,6 +112,78 @@ class _QuizPageState extends State<QuizPage> {
       ),
     );
   }
+
+  Future<bool?> _showSubmitDialog(BuildContext context) {
+    var completed = context.read<QuizModel>().completed;
+    if (completed) {
+      return showDialog<bool?>(
+        context: context,
+        builder: (context) => AlertDialog(
+          content: const Text('Do you confirm to submit?'),
+          actions: [
+            TextButton(
+              onPressed: Navigator.of(context).pop,
+              child: const Text('no'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('yes'),
+            ),
+          ],
+        ),
+      );
+    }
+    return showDialog<bool?>(
+      context: context,
+      builder: (context) => AlertDialog(
+        content: const Text('You are missing some answers, continue?'),
+        actions: [
+          TextButton(
+            onPressed: Navigator.of(context).pop,
+            child: const Text('yes'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('submit anyway'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _showOverviewDialog(int value, BuildContext context) {
+    return Dialog(
+      child: Container(
+        decoration: BoxDecoration(
+          color: Theme.of(context).cardColor,
+          borderRadius: BorderRadius.circular(10),
+        ),
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            const Text('Quiz Overview'),
+            _Overview(
+              currentIndex: value,
+              itemOnTap: (index) => _pageController.animateToPage(
+                index,
+                duration: _kAnimationDuration,
+                curve: _kAnimationCurve,
+              ),
+            ),
+            const SizedBox(height: 15),
+            TextButton(
+              onPressed: () {
+                Navigator.pop(context);
+              },
+              child: const Text('Close'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }
 
 class _Overview extends StatelessWidget {
@@ -107,17 +199,19 @@ class _Overview extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final quizItems = context.read<QuizModel>().quizItems;
-    final indexTemp = _getItems(quizItems.length);
 
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: indexTemp.map(
-        (e) {
+    return Wrap(
+      direction: Axis.horizontal,
+      alignment: WrapAlignment.start,
+      spacing: 8.0,
+      runSpacing: 4.0,
+      children: quizItems.mapIndexed(
+        (i, e) {
           final isCurrent = e == currentIndex;
           return RawMaterialButton(
-            onPressed: isCurrent ? null : () => itemOnTap?.call(e),
+            onPressed: isCurrent ? null : () => itemOnTap?.call(i),
             shape: CircleBorder(
-              side: quizItems[e].answered
+              side: e.answered
                   ? const BorderSide(color: Colors.green)
                   : isCurrent
                       ? BorderSide.none
@@ -127,7 +221,7 @@ class _Overview extends StatelessWidget {
             fillColor:
                 isCurrent ? Theme.of(context).primaryColor : Colors.white,
             child: Text(
-              '${e + 1}',
+              '${i + 1}',
               style: TextStyle(
                 color:
                     isCurrent ? Colors.white : Theme.of(context).primaryColor,
@@ -137,16 +231,6 @@ class _Overview extends StatelessWidget {
         },
       ).toList(),
     );
-  }
-
-  List<int> _getItems(int quizCount) {
-    final resultLength = min(quizCount, 5);
-    final centerOffset = resultLength ~/ 2;
-    final startItem = min(
-      max(currentIndex - centerOffset, 0),
-      quizCount - resultLength,
-    );
-    return List.generate(resultLength, (index) => startItem + index);
   }
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -34,7 +34,7 @@ packages:
     source: hosted
     version: "1.1.1"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.2
   http: ^1.1.0
+  collection: ^1.17.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 功能修改
* 新增了"上一题" 和 "下一题" 按钮。
* 修改了题目指示器，并移动到dialog中显示。(添加按钮后，之前那个指示器感觉太占空间)。
* 新增文本用于显示当前题目序号以及题目总数量。
## 截图
<img width="356" alt="image" src="https://github.com/h65wang/flutter_interview_questions/assets/47512530/d41d5412-b9e0-41a3-b21f-62b257013dcc">
