### PR TITLE
布局、交互优化

### DIFF
--- a/lib/components/indicator.dart
+++ b/lib/components/indicator.dart
@@ -19,17 +19,12 @@ class IndicatorWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 4),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          _buildPrevious(),
-          const Spacer(),
-          _buildTextButton(context),
-          const Spacer(),
-          _buildNext(),
-        ],
+    return SizedBox(
+      height: 44,
+      child: NavigationToolbar(
+        leading: _buildPrevious(),
+        middle: _buildTextButton(context),
+        trailing: _buildNext(),
       ),
     );
   }
@@ -51,6 +46,7 @@ class IndicatorWidget extends StatelessWidget {
       return TextButton(
         onPressed: onTapSubmit,
         child: Row(
+          mainAxisSize: MainAxisSize.min,
           children: [
             Text('submit'),
             const Icon(Icons.done),
@@ -61,6 +57,7 @@ class IndicatorWidget extends StatelessWidget {
     return TextButton(
       onPressed: () => onTap(current + 1),
       child: Row(
+        mainAxisSize: MainAxisSize.min,
         children: [
           Text('Next'),
           Icon(Icons.arrow_forward),
@@ -75,6 +72,7 @@ class IndicatorWidget extends StatelessWidget {
       child: TextButton(
         onPressed: () => onTap(current - 1),
         child: Row(
+          mainAxisSize: MainAxisSize.min,
           children: [
             Icon(Icons.arrow_back),
             Text('Previous'),

--- a/lib/model/quiz_item.dart
+++ b/lib/model/quiz_item.dart
@@ -19,7 +19,7 @@ class QuizItem {
   bool get correct => choices.every(
       (choice) => (choice.content == question.answer) == choice.selected);
 
-  bool previousFlag = false;//上一个问题是否已经做完  
+  bool previousFlag = false; //上一个问题是否已经做完
   set isAnswered(bool flage) {
     isAnswered = flage;
   }

--- a/lib/model/quiz_model.dart
+++ b/lib/model/quiz_model.dart
@@ -19,7 +19,8 @@ class QuizModel extends ChangeNotifier {
   bool get questionIsEmpty => allQuestions.isEmpty;
   int get totalCount => allQuestions.values.expand((e) => e).length;
 
-  bool isLoading = false;
+  bool _isLoading = false;
+  bool get isLoading => _isLoading;
 
   bool get completed => quizItems.every((item) => item.answered);
 
@@ -27,10 +28,10 @@ class QuizModel extends ChangeNotifier {
     fetchAllQuestions();
   }
 
-  Future fetchAllQuestions() async {
+  Future<void> fetchAllQuestions() async {
     const root = 'https://raw.githubusercontent.com/h65wang'
         '/flutter_interview_questions/main/public';
-    isLoading = true;
+    _isLoading = true;
     notifyListeners();
 
     final res = await http.get(Uri.parse('$root/index.json'));
@@ -49,7 +50,7 @@ class QuizModel extends ChangeNotifier {
     }
     allQuestions = resultTemp;
 
-    isLoading = false;
+    _isLoading = false;
     notifyListeners();
   }
 


### PR DESCRIPTION
1. [`IndicatorWidget`](https://github.com/h65wang/flutter_interview_questions/blob/main/lib/components/indicator.dart)实现由`Row`改为`NavigationToolbar`
2. 在`PreviewDialog`中点击题目对应按钮，跳转到对应题目前，会先关闭dialog
3. `QuizModel`中`isLoading`改为私有，并通过`get`暴露